### PR TITLE
free process memory and not thread memory

### DIFF
--- a/process-injection/process-injection.cpp
+++ b/process-injection/process-injection.cpp
@@ -67,7 +67,7 @@ int main(int argc, char** argv) {
             // Halt execution until thread returns
             WaitForSingleObject(hThread, INFINITE);
             // Free allocated memory in `mspaint.exe`
-            VirtualFreeEx(hThread, allocated_mem, 0, MEM_RELEASE);
+            VirtualFreeEx(hProcess, allocated_mem, 0, MEM_RELEASE);
             // Close the handle to the created thread
             CloseHandle(hThread);
             // Close the handle to `mspaint.exe` process


### PR DESCRIPTION
Maybe I am wrong but I think that it must be freed the memory of the process and not of the thread injected.